### PR TITLE
Add FestiSoundArtist entity and many-to-many relation with Festival

### DIFF
--- a/FestiSounds/src/main/java/com/example/festisounds/Modules/FestiSoundArtists/Entities/FestiSoundArtist.java
+++ b/FestiSounds/src/main/java/com/example/festisounds/Modules/FestiSoundArtists/Entities/FestiSoundArtist.java
@@ -1,0 +1,36 @@
+package com.example.festisounds.Modules.FestiSoundArtists.Entities;
+
+import com.example.festisounds.Modules.Festival.Entities.Festival;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.GenericGenerator;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "festisound_artist")
+public class FestiSoundArtist {
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(generator = "uuid-hibernate-generator")
+    @GenericGenerator(name = "uuid-hibernate-generator", strategy = "org.hibernate.id.UUIDGenerator")
+    private UUID id;
+
+    @Column(name = "artist_name", nullable = false, length = 100)
+    private String artistName;
+
+    @Builder.Default
+    @ManyToMany
+    @JoinTable(
+            name = "festival_artist",
+            joinColumns = @JoinColumn(name = "festisound_artist_id"),
+            inverseJoinColumns = @JoinColumn(name = "festival_id"))
+    private Set<Festival> festivals = new HashSet<>();
+}

--- a/FestiSounds/src/main/java/com/example/festisounds/Modules/FestiSoundArtists/Repositories/FestiSoundArtistRepository.java
+++ b/FestiSounds/src/main/java/com/example/festisounds/Modules/FestiSoundArtists/Repositories/FestiSoundArtistRepository.java
@@ -1,0 +1,9 @@
+package com.example.festisounds.Modules.FestiSoundArtists.Repositories;
+
+import com.example.festisounds.Modules.FestiSoundArtists.Entities.FestiSoundArtist;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface FestiSoundArtistRepository extends JpaRepository<FestiSoundArtist, UUID> {
+}

--- a/FestiSounds/src/main/java/com/example/festisounds/Modules/Festival/Entities/Festival.java
+++ b/FestiSounds/src/main/java/com/example/festisounds/Modules/Festival/Entities/Festival.java
@@ -1,5 +1,6 @@
 package com.example.festisounds.Modules.Festival.Entities;
 
+import com.example.festisounds.Modules.FestiSoundArtists.Entities.FestiSoundArtist;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -9,6 +10,8 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.Instant;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 @Getter
@@ -41,6 +44,14 @@ public class Festival {
 //    @ManyToMany
 //    private festivalArtist artist; festivalId spotifyId name
 
+    @Builder.Default
+    @ManyToMany
+    @JoinTable(
+            name = "festival_artist",
+            joinColumns = @JoinColumn(name = "festival_id"),
+            inverseJoinColumns = @JoinColumn(name = "festisound_artist_id"))
+    private Set<FestiSoundArtist> artists = new HashSet<>();
+
 //    @OneToMany
 //    festivalGenre name
 
@@ -63,4 +74,14 @@ public class Festival {
 
     @Column(name = "festival_organizer", nullable = false, length = 100)
     private String festivalOrganizer;
+
+    public void addArtist(FestiSoundArtist artist) {
+        this.artists.add(artist);
+        artist.getFestivals().add(this);
+    }
+
+    public void removeArtist(FestiSoundArtist artist) {
+        this.artists.remove(artist);
+        artist.getFestivals().remove(this);
+    }
 }


### PR DESCRIPTION
Added a new FestiSoundArtist entity to represent artists managed within the FestiSounds application. This includes adding a repository for handling database interactions for this entity. Further, amended Festival entity to establish a many-to-many relationship with FestiSoundArtist which allows to link several artists to multiple festivals they are performing at. Additionally, helper methods for adding and removing artists from festivals were implemented. This change provides better data organization and makes it easier to manage artist-related information. It will aid in creating detailed insights for festivals and artists alike.